### PR TITLE
Additional changes to PR

### DIFF
--- a/src/app/components/sandbox/Preview/index.js
+++ b/src/app/components/sandbox/Preview/index.js
@@ -57,8 +57,8 @@ type State = {
 };
 
 export default class Preview extends React.PureComponent {
-  initialPath: string
-  
+  initialPath: string;
+
   constructor(props: Props) {
     super(props);
 
@@ -77,7 +77,7 @@ export default class Preview extends React.PureComponent {
     // we need a value that doesn't change when receiving `initialPath`
     // from the query params, or the iframe will continue to be re-rendered
     // when the user navigates the iframe app, which shows the loading screen
-    this.initialPath = this.state.urlInAddressBar
+    this.initialPath = this.state.urlInAddressBar;
   }
 
   static defaultProps = {
@@ -166,8 +166,7 @@ export default class Preview extends React.PureComponent {
     const element = document.getElementById('sandbox');
 
     if (element) {
-      const { urlInAddressBar: url } = this.state
-      element.contentWindow.postMessage(message, frameUrl(url));
+      element.contentWindow.postMessage(message, frameUrl());
     }
   };
 

--- a/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
+++ b/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
@@ -35,7 +35,7 @@ const CancelDefaultModule = styled.div`
   position: relative;
   top: -10px;
   cursor: pointer;
-`
+`;
 
 const FilesContainer = styled.div`
   max-height: 300px;
@@ -153,30 +153,17 @@ const mapStateToProps = createSelector(
 class ShareView extends React.PureComponent {
   props: Props;
 
-  constructor(props, context) {
-    super(props, context);
+  state = {
+    showEditor: true,
+    showPreview: true,
+    defaultModule: null,
+    autoResize: false,
+    hideNavigation: false,
+    isCurrentModuleView: false,
+    fontSize: 14,
+    initialPath: '',
+  };
 
-    this.state = {
-      showEditor: true,
-      showPreview: true,
-      defaultModule: null,
-      autoResize: false,
-      hideNavigation: false,
-      isFileEval: !props.sandbox.isInProjectView, // thats why i moved this to the constructor :)
-      fontSize: 14,
-      initialPath: ''
-    }
-  }
-
-  componentWillReceiveProps(nextProps) {
-    const { sandbox: { isInProjectView } } = nextProps
-
-    if (isInProjectView !== this.props.sandbox.isInProjectView) {
-      this.setState({ isFileEval: !isInProjectView })
-    }
-  }
-
-  
   handleChange = e => this.setState({ message: e.target.value });
 
   handleSend = () => {
@@ -202,9 +189,9 @@ class ShareView extends React.PureComponent {
       showPreview,
       autoResize,
       hideNavigation,
-      isFileEval,
+      isCurrentModuleView,
       fontSize,
-      initialPath
+      initialPath,
     } = this.state;
 
     const options = {};
@@ -228,8 +215,8 @@ class ShareView extends React.PureComponent {
       options.hidenavigation = 1;
     }
 
-    if (isFileEval) {
-      options.isFileEval = 1;
+    if (isCurrentModuleView) {
+      options.moduleview = 1;
     }
 
     if (fontSize !== 14) {
@@ -237,7 +224,7 @@ class ShareView extends React.PureComponent {
     }
 
     if (initialPath) {
-      options.initialPath = initialPath;
+      options.initialpath = initialPath;
     }
 
     return optionsToParameterizedUrl(options);
@@ -254,10 +241,10 @@ class ShareView extends React.PureComponent {
 
     return protocolAndHost() + embedUrl(sandbox) + this.getOptionsUrl();
   };
-  
+
   setInitialPath = ({ target }) => {
-    const initialPath = target.value
-    this.setState({ initialPath })
+    const initialPath = target.value;
+    this.setState({ initialPath });
   };
 
   getIframeScript = () =>
@@ -291,8 +278,8 @@ class ShareView extends React.PureComponent {
     this.setState({ hideNavigation });
   };
 
-  setIsFileEval = (isFileEval: boolean) => {
-    this.setState({ isFileEval });
+  setIsCurrentModuleView = (isCurrentModuleView: boolean) => {
+    this.setState({ isCurrentModuleView });
   };
 
   setFontSize = (fontSize: number) => [this.setState({ fontSize })];
@@ -305,9 +292,9 @@ class ShareView extends React.PureComponent {
       showPreview,
       autoResize,
       hideNavigation,
-      isFileEval,
+      isCurrentModuleView,
       fontSize,
-      initialPath
+      initialPath,
     } = this.state;
 
     const defaultModule =
@@ -343,9 +330,10 @@ class ShareView extends React.PureComponent {
                       setValue={this.setHideNavigation}
                     />
                     <PaddedPreference
-                      title="File eval"
-                      value={isFileEval}
-                      setValue={this.setIsFileEval}
+                      title="Current Module View"
+                      tooltip="Only show the module that's currently open"
+                      value={isCurrentModuleView}
+                      setValue={this.setIsCurrentModuleView}
                     />
                     <PaddedPreference
                       title="Font size"
@@ -357,9 +345,9 @@ class ShareView extends React.PureComponent {
                     <LinkName>Project Initial Path</LinkName>
                     <input
                       onFocus={this.select}
-                      placeholder='e.g: /home'
+                      placeholder="e.g: /home"
                       value={initialPath}
-                      onChange={this.setInitialPath} 
+                      onChange={this.setInitialPath}
                     />
                   </Inputs>
                   <div>
@@ -383,11 +371,10 @@ class ShareView extends React.PureComponent {
                   </div>
                   <div>
                     <h4>Default module to show</h4>
-                    {this.state.defaultModule  &&
+                    {this.state.defaultModule &&
                       <CancelDefaultModule onClick={this.clearDefaultModule}>
                         cancel
-                      </CancelDefaultModule>
-                    }
+                      </CancelDefaultModule>}
 
                     <FilesContainer>
                       <Files

--- a/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
+++ b/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
@@ -379,8 +379,8 @@ class ShareView extends React.PureComponent {
                     <FilesContainer>
                       <Files
                         modules={modules}
-                        directories={directories}
                         directoryId={null}
+                        directories={directories}
                         currentModule={defaultModule}
                         setCurrentModule={this.setDefaultModule}
                       />

--- a/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
+++ b/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
@@ -323,7 +323,7 @@ class ShareView extends React.PureComponent {
                       setValue={this.setHideNavigation}
                     />
                     <PaddedPreference
-                      title="Current Module View"
+                      title="Show current module view"
                       tooltip="Only show the module that's currently open"
                       value={isCurrentModuleView}
                       setValue={this.setIsCurrentModuleView}

--- a/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
+++ b/src/app/pages/Sandbox/Editor/Content/Header/ShareView.js
@@ -29,14 +29,6 @@ const Container = styled.div`
   height: 100%;
 `;
 
-const CancelDefaultModule = styled.div`
-  text-decoration: underline;
-  color: rgb(82, 174, 217);
-  position: relative;
-  top: -10px;
-  cursor: pointer;
-`;
-
 const FilesContainer = styled.div`
   max-height: 300px;
   overflow: auto;
@@ -196,7 +188,8 @@ class ShareView extends React.PureComponent {
 
     const options = {};
 
-    if (defaultModule) {
+    const mainModuleShortid = findMainModule(this.props.modules).shortid;
+    if (defaultModule && defaultModule !== mainModuleShortid) {
       options.module = defaultModule;
     }
 
@@ -298,7 +291,7 @@ class ShareView extends React.PureComponent {
     } = this.state;
 
     const defaultModule =
-      this.state.defaultModule || findMainModule(modules).id;
+      this.state.defaultModule || findMainModule(modules).shortid;
 
     return (
       <Container>
@@ -371,10 +364,6 @@ class ShareView extends React.PureComponent {
                   </div>
                   <div>
                     <h4>Default module to show</h4>
-                    {this.state.defaultModule &&
-                      <CancelDefaultModule onClick={this.clearDefaultModule}>
-                        cancel
-                      </CancelDefaultModule>}
 
                     <FilesContainer>
                       <Files

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
@@ -9,6 +9,7 @@ import type { Module, Directory, ModuleError } from 'common/types';
 import sandboxActionCreators from 'app/store/entities/sandboxes/actions';
 import { validateTitle } from 'app/store/entities//sandboxes/modules/validator';
 import contextMenuActionCreators from 'app/store/context-menu/actions';
+import { getModuleParents } from 'app/store/entities/sandboxes/modules/selectors';
 
 import Entry from './Entry';
 import DirectoryChildren from './DirectoryChildren';
@@ -62,9 +63,18 @@ class DirectoryEntry extends React.PureComponent {
   constructor(props) {
     super(props);
 
+    const { id, modules, directories, currentModuleId } = this.props;
+    const currentModuleParents = getModuleParents(
+      modules,
+      directories,
+      currentModuleId,
+    );
+
+    const isParentOfModule = currentModuleParents.includes(id);
+
     this.state = {
       creating: '',
-      open: props.root,
+      open: props.root || isParentOfModule,
     };
   }
 

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/DirectoryEntry/index.js
@@ -13,13 +13,14 @@ import contextMenuActionCreators from 'app/store/context-menu/actions';
 import Entry from './Entry';
 import DirectoryChildren from './DirectoryChildren';
 
-const EntryContainer = styled.div`
-  position: relative;
-`;
+const EntryContainer = styled.div`position: relative;`;
 
 const Overlay = styled.div`
   position: absolute;
-  top: 0; bottom: 0; left: 0; right: 0;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
   background-color: rgba(0, 0, 0, 0.3);
   display: ${props => (props.isOver ? 'block' : 'none')};
 `;
@@ -36,7 +37,6 @@ const mapDispatchToProps = dispatch => ({
 type Props = {
   id: string,
   shortid: string,
-  currentDirectoryShortid: string,
   sandboxId: string,
   root: ?boolean,
   title: string,

--- a/src/app/pages/Sandbox/Editor/Workspace/Files/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/Files/index.js
@@ -52,7 +52,11 @@ class Files extends React.PureComponent {
 
     const mainModule = findMainModule(modules);
     const { currentModule: currentModuleId } = sandbox;
-    const currentModule = findCurrentModule(modules, currentModuleId, mainModule);
+    const currentModule = findCurrentModule(
+      modules,
+      currentModuleId,
+      mainModule,
+    );
 
     return (
       <DirectoryEntry
@@ -63,7 +67,6 @@ class Files extends React.PureComponent {
         directories={sortBy(directories, 'title')}
         isInProjectView={sandbox.isInProjectView}
         currentModuleId={currentModule.id}
-        currentDirectoryShortid={currentModule.directoryShortid}
         errors={sandbox.errors}
         id={null}
         shortid={null}

--- a/src/app/pages/Sandbox/Editor/Workspace/WorkspaceItem.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/WorkspaceItem.js
@@ -11,7 +11,9 @@ const ChildContainer = styled.div`
   overflow: ${props => (props.open ? 'inherit' : 'hidden')};
   height: ${props => (props.open ? '100%' : 0)};
 
-  ${({ disabled }) => disabled && `
+  ${({ disabled }) =>
+    disabled &&
+    `
     pointer-events: none;
 
     &:after {
@@ -29,7 +31,7 @@ const ChildContainer = styled.div`
       right: 0;
       background-color: rgba(0, 0, 0, 0.4);
     }
-  `}
+  `};
 `;
 
 const ItemHeader = styled.div`
@@ -65,7 +67,6 @@ type Props = {
   children: React.Element,
   defaultOpen: ?boolean,
   disabled: ?string,
-  custom: ?React.Element
 };
 
 export default class WorkspaceItem extends React.PureComponent {
@@ -81,14 +82,15 @@ export default class WorkspaceItem extends React.PureComponent {
   toggleOpen = () => this.setState({ open: !this.state.open });
 
   render() {
-    const { children, title, disabled, custom } = this.props;
+    const { children, title, disabled } = this.props;
     const { open } = this.state;
 
     return (
       <div>
         <ItemHeader onClick={this.toggleOpen}>
-          <Title>{title}</Title>
-          {open && custom}
+          <Title>
+            {title}
+          </Title>
           <ExpandIconContainer open={open} />
         </ItemHeader>
         <ChildContainer disabled={disabled} open={open}>

--- a/src/app/pages/Sandbox/Editor/Workspace/index.js
+++ b/src/app/pages/Sandbox/Editor/Workspace/index.js
@@ -14,8 +14,6 @@ import { usersSelector } from 'app/store/entities/users/selectors';
 import showAlternativeComponent from 'app/hoc/show-alternative-component';
 import fadeIn from 'app/utils/animation/fade-in';
 
-import Tooltip from 'app/components/Tooltip';
-
 import Files from './Files';
 import Dependencies from './Dependencies';
 import Project from './Project';
@@ -42,19 +40,15 @@ type Props = {
   sandboxActions: typeof sandboxActionCreators,
   preventTransition: boolean,
   user: User,
-  isInProjectView: boolean,
-  toggleFileEval: Function
 };
 
 const mapStateToProps = createSelector(
   modulesFromSandboxNotSavedSelector,
   usersSelector,
   (_, props) => props.sandbox && props.sandbox.author,
-  (_, props) => props.sandbox && props.sandbox.isInProjectView,
-  (preventTransition, users, author, isInProjectView) => ({
+  (preventTransition, users, author) => ({
     preventTransition,
     user: users[author],
-    isInProjectView
   }),
 );
 
@@ -62,25 +56,11 @@ const mapDispatchToProps = dispatch => ({
   sandboxActions: bindActionCreators(sandboxActionCreators, dispatch),
 });
 
-const mergeProps = (stateProps, { sandboxActions }, props) => ({
-  ...stateProps,
-  ...props,
-  sandboxActions,
-  toggleFileEval: e => {
-    e.stopPropagation()
-    const { setProjectView } = sandboxActions;
-    setProjectView(props.sandbox.id, !stateProps.isInProjectView);
-  }
-});
-
-
 const Workspace = ({
   sandbox,
   user,
   preventTransition,
   sandboxActions,
-  isInProjectView,
-  toggleFileEval,
 }: Props) =>
   <Container>
     <Logo />
@@ -102,16 +82,7 @@ const Workspace = ({
       />
     </WorkspaceItem>
 
-    <WorkspaceItem
-      defaultOpen
-      title="Files"
-      custom={
-        <FileEvalSwitch 
-          isInProjectView={isInProjectView}
-          toggleFileEval={toggleFileEval} 
-        />
-      }
-    >
+    <WorkspaceItem defaultOpen title="Files">
       <Files sandbox={sandbox} sandboxActions={sandboxActions} />
     </WorkspaceItem>
 
@@ -144,46 +115,5 @@ const Workspace = ({
 const Skeleton = () => <Container />;
 
 export default showAlternativeComponent(Skeleton, ['sandbox'])(
-  connect(mapStateToProps, mapDispatchToProps, mergeProps)(Workspace),
+  connect(mapStateToProps, mapDispatchToProps)(Workspace),
 );
-
-const FileContainer = styled.div`
-  margin-left: auto;
-  margin-right: 20px;
-`;
-
-const FileEvalCheckbox = styled.input`
-  transform: scale(.8);
-`
-const FileEvalLabel = styled.label`
-  font-size: 14px;
-  color: rgba(255, 255, 255, 0.6);
-  cursor: pointer;
-`
-
-const FileEvalSwitch = ({
-  isInProjectView,
-  toggleFileEval,
-}: {
-  isInProjectView: boolean,
-  toggleFileEval: Function,
-}) =>
-  <FileContainer>
-    <Tooltip
-      title="Eval mode allows you to re-evaluate each file as you click it. It's great for galleries."
-      position="right"
-    >
-      <FileEvalCheckbox
-        id='fileEval'
-        type='checkbox'
-        checked={!isInProjectView}
-        onClick={toggleFileEval}
-      />
-      <FileEvalLabel
-        htmlFor='fileEval'
-        onClick={e => e.stopPropagation()}
-      > File eval
-      </FileEvalLabel>
-    </Tooltip>
-  </FileContainer>
-

--- a/src/app/store/entities/sandboxes/modules/selectors.js
+++ b/src/app/store/entities/sandboxes/modules/selectors.js
@@ -13,7 +13,7 @@ export const findMainModule = (modules: Module[]) =>
 export const findCurrentModule = (
   modules: Module[],
   currentModuleId: string,
-  mainModule: Module
+  mainModule: Module,
 ): Module =>
   modules.find(m => m.id === currentModuleId) ||
   modules.find(m => m.shortid === currentModuleId) || // deep-links requires this
@@ -43,6 +43,28 @@ export const getModulePath = (
     directory = findByShortid(directories, directory.directoryShortid);
   }
   return path;
+};
+
+/**
+ * Return an array of the ids of the directories that are the parents of the given module
+ */
+export const getModuleParents = (
+  modules: Array<Module>,
+  directories: Array<Directory>,
+  id: string,
+) => {
+  const module = findById(modules, id);
+
+  if (!module) return [];
+
+  let directory = findByShortid(directories, module.directoryShortid);
+  let directoryIds = [];
+  while (directory != null) {
+    directoryIds = [...directoryIds, directory.id];
+    directory = findByShortid(directories, directory.directoryShortid);
+  }
+
+  return directoryIds;
 };
 
 export const modulesFromSandboxSelector = createSelector(

--- a/src/app/store/entities/sandboxes/modules/selectors.test.js
+++ b/src/app/store/entities/sandboxes/modules/selectors.test.js
@@ -1,0 +1,60 @@
+import { getModuleParents } from './selectors';
+
+describe('entities', () => {
+  describe('modules', () => {
+    describe('selectors', () => {
+      it('can find the correct parent directories of a module', () => {
+        const directories = [
+          {
+            id: 'i1',
+            shortid: '1',
+            directoryShortid: null,
+          },
+          {
+            id: 'i2',
+            shortid: '2',
+            directoryShortid: '1',
+          },
+        ];
+
+        const modules = [
+          {
+            id: 'm3',
+            shortid: '3',
+            directoryShortid: '2',
+          },
+        ];
+
+        expect(getModuleParents(modules, directories, 'm3')).toEqual([
+          'i2',
+          'i1',
+        ]);
+      });
+
+      it('can find no parent directories of a module', () => {
+        const directories = [
+          {
+            id: 'i1',
+            shortid: '1',
+            directoryShortid: null,
+          },
+          {
+            id: 'i2',
+            shortid: '2',
+            directoryShortid: '1',
+          },
+        ];
+
+        const modules = [
+          {
+            id: 'm3',
+            shortid: '3',
+            directoryShortid: null,
+          },
+        ];
+
+        expect(getModuleParents(modules, directories, 'm3')).toEqual([]);
+      });
+    });
+  });
+});

--- a/src/common/url.js
+++ b/src/common/url.js
@@ -7,7 +7,7 @@ export const getSandboxOptions = (url: string) => {
     result.currentModule = moduleMatch[3];
   }
 
-  const initialPathMatch = url.match(/(\?|&)(initialPath)=([^&]+)/);
+  const initialPathMatch = url.match(/(\?|&)(initialpath)=([^&]+)/);
   if (initialPathMatch) {
     result.initialPath = decodeURIComponent(initialPathMatch[3]);
   }
@@ -19,7 +19,7 @@ export const getSandboxOptions = (url: string) => {
 
   result.isPreviewScreen = url.includes('view=preview');
   result.isEditorScreen = url.includes('view=editor');
-  
+
   // If there is no view specified and the width of the window is <800 we want
   // to default to preview
   if (!result.isPreviewScreen && !result.isEditorScreen) {
@@ -29,7 +29,7 @@ export const getSandboxOptions = (url: string) => {
   }
 
   result.hideNavigation = url.includes('hidenavigation=1');
-  result.isInProjectView = !url.includes('isFileEval=1');
+  result.isInProjectView = !url.includes('moduleview=1');
   result.autoResize = url.includes('autoresize=1');
 
   return result;

--- a/src/embed/App.js
+++ b/src/embed/App.js
@@ -78,7 +78,7 @@ export default class App extends React.PureComponent {
       fontSize: fontSize || 16,
       showEditor: !isPreviewScreen,
       showPreview: !isEditorScreen,
-      isInProjectView: isInProjectView || !currentModule,
+      isInProjectView,
       currentModule,
       initialPath,
       sidebarOpen: false,
@@ -106,10 +106,11 @@ export default class App extends React.PureComponent {
         .then(res => res.json())
         .then(camelizeKeys);
 
-      const currentModule = this.state.currentModule ||
-          response.data.modules.find(
-            m => m.title === 'index.js' && m.directoryShortid == null,
-          ).shortid
+      const currentModule =
+        this.state.currentModule ||
+        response.data.modules.find(
+          m => m.title === 'index.js' && m.directoryShortid == null,
+        ).shortid;
 
       this.setState({ sandbox: response.data, currentModule });
     } catch (e) {
@@ -183,6 +184,7 @@ export default class App extends React.PureComponent {
           hideNavigation={this.state.hideNavigation}
           autoResize={this.state.autoResize}
           fontSize={this.state.fontSize}
+          initialPath={this.state.initialPath}
         />
       </Container>
     );

--- a/src/embed/components/Content.js
+++ b/src/embed/components/Content.js
@@ -33,6 +33,7 @@ type Props = {
   hideNavigation: boolean,
   autoResize: boolean,
   fontSize: number,
+  initialPath: ?string,
 };
 
 type State = {
@@ -230,6 +231,7 @@ export default class Content extends React.PureComponent {
               setProjectView={this.props.setProjectView}
               hideNavigation={hideNavigation}
               setFrameHeight={this.handleResize}
+              initialPath={this.props.initialPath}
               errors={errors}
             />
           </Split>}

--- a/src/embed/components/Files.js
+++ b/src/embed/components/Files.js
@@ -7,9 +7,7 @@ import type { Module, Directory } from 'common/types';
 
 import File from './File';
 
-const Container = styled.div`
-  line-height: 1;
-`;
+const Container = styled.div`line-height: 1;`;
 
 type Props = {
   modules: Array<Module>,
@@ -38,7 +36,7 @@ const Files = ({
 
   return (
     <Container>
-      {sortBy(childrenDirectories, d => d.title).map(d => (
+      {sortBy(childrenDirectories, d => d.title).map(d =>
         <div key={d.shortid}>
           <File
             id={d.shortid}
@@ -55,9 +53,9 @@ const Files = ({
             setCurrentModule={setCurrentModule}
             currentModule={currentModule}
           />
-        </div>
-      ))}
-      {sortBy(childrenModules, m => m.title).map(m => (
+        </div>,
+      )}
+      {sortBy(childrenModules, m => m.title).map(m =>
         <File
           id={m.shortid}
           title={m.title}
@@ -67,8 +65,8 @@ const Files = ({
           setCurrentModule={setCurrentModule}
           active={m.shortid === currentModule}
           alternative={m.title === 'index.js' && m.directoryShortid == null}
-        />
-      ))}
+        />,
+      )}
     </Container>
   );
 };


### PR DESCRIPTION
Hey! I did the changes we discussed.

Changes:

1. Remove File Eval from Workspace
   - I think it's better to have one switch for the module preview, this switch will change after the next update so it's more clear for the user. For now I want to keep it so the user doesn't see two changes in a span of 1 month.
2. Rename File Eval to Current Module View
3. Remove directoryShortId from Files component
   - We don't need a directoryShortId from the files, we are able to find the directory based on `currentModuleId`
4. Add auto open directory
5. Change currentModule in ShareView to select defaultModule bty default, omit from url when it's defaultModule